### PR TITLE
Use decimal rounding and print output in spreadsheet compatible format

### DIFF
--- a/opl/status_data.py
+++ b/opl/status_data.py
@@ -225,8 +225,15 @@ def doit_set(status_data, set_this):
         status_data.set(key, value)
 
 
-def doit_print_oneline(status_data, get_this):
-    print(' '.join([str(status_data.get(i)) for i in get_this]))
+def doit_print_oneline(status_data, get_this, get_rounding):
+    if not get_rounding:
+        print('\t'.join([str(status_data.get(i)) for i in get_this]))
+    else:
+        for i in get_this:
+            if isinstance(i,float):
+                print('{:.2f}'.format(i),end='\t')
+            else:
+                print('{}'.format(i),end='\t')
 
 
 def doit_additional(status_data, additional, monitoring_start, monitoring_end, args):
@@ -267,6 +274,8 @@ def main():
                         help='"started" is set when the status data file is created, "ended" is set when this is used')
     parser.add_argument('--info', action='store_true',
                         help='Show basic info from status data file')
+    parser.add_argument('--decimal-rounding', action='store_true',
+                         help='Rounding a number to its hundredths, leaving 2 numbers after decimal point')
     for name, plugin in cluster_read.PLUGINS.items():
         plugin.add_args(parser)
 
@@ -276,7 +285,7 @@ def main():
         if len(args.set_now) > 0:
             doit_set(status_data, [k + "=%NOW%" for k in args.set_now])
         if len(args.get) > 0:
-            doit_print_oneline(status_data, args.get)
+            doit_print_oneline(status_data, args.get, args.decimal_rounding)
         if args.additional:
             doit_additional(
                 status_data,

--- a/opl/status_data.py
+++ b/opl/status_data.py
@@ -230,10 +230,11 @@ def doit_print_oneline(status_data, get_this, get_rounding):
         print('\t'.join([str(status_data.get(i)) for i in get_this]))
     else:
         for i in get_this:
-            if isinstance(i,float):
-                print('{:.2f}'.format(i),end='\t')
+            if isinstance(status_data.get(i),float):
+                print('{:.2f}'.format(status_data.get(i)),end='\t')
             else:
-                print('{}'.format(i),end='\t')
+                print('{}'.format(status_data.get(i)),end='\t')
+        print()
 
 
 def doit_additional(status_data, additional, monitoring_start, monitoring_end, args):


### PR DESCRIPTION
##### Highlights of the PR: 
1. Added a new command line option, `decimal-rounding` to get only two numbers after the decimal point. 
2. Also used `\t` special character in `print` statements to get output in spreadsheet compatible format. 