### PR TITLE
Fix scope of parse_ibutsu_metadata

### DIFF
--- a/opl/junit_cli.py
+++ b/opl/junit_cli.py
@@ -157,7 +157,7 @@ class JUnitXmlPlus(junitparser.JUnitXml):
             "Authorization": f"Bearer {token}"
         }
         if metadata:
-            metadata = json.dumps(parse_ibutsu_metadata(metadata))
+            metadata = json.dumps(self.parse_ibutsu_metadata(metadata))
         res = requests.post(
             f'{host}/api/import',
             headers=headers,
@@ -171,7 +171,7 @@ class JUnitXmlPlus(junitparser.JUnitXml):
         else:
             logging.debug(res.text)
 
-    def parse_ibutsu_metadata(metadata_list):
+    def parse_ibutsu_metadata(self, metadata_list):
         """Parse the metadata from a set of strings to a dictionary"""
         metadata = {}
         # Loop through the list of metadata values


### PR DESCRIPTION
Fixing following error. It was working locally for me since earlier I tested using standalone file. 
```
Traceback (most recent call last):
  File "/home/jenkins/workspace/InsightsEngine_runner/venv/bin/junit_cli.py", line 11, in <module>
    load_entry_point('opl-rhcloud-perf-team', 'console_scripts', 'junit_cli.py')()
  File "/home/jenkins/workspace/InsightsEngine_runner/venv/src/opl-rhcloud-perf-team/opl/junit_cli.py", line 469, in main
    junit.ibutsu_upload(args.host, args.token, args.project, not args.noverify, args.file, args.metadata)
  File "/home/jenkins/workspace/InsightsEngine_runner/venv/src/opl-rhcloud-perf-team/opl/junit_cli.py", line 160, in ibutsu_upload
    metadata = json.dumps(parse_ibutsu_metadata(metadata))
NameError: name 'parse_ibutsu_metadata' is not defined
```