### PR TITLE
updating column name according to api_tenant table schema

### DIFF
--- a/opl/rbac_populate.py
+++ b/opl/rbac_populate.py
@@ -170,7 +170,7 @@ def create_principal(cursor, account):
     user_uuid = str(uuid.uuid4())
     user_name = "user-" + user_uuid
     logging.info(f"Creating principal username = {user_name}")
-    cursor.execute("INSERT INTO public.management_principal (uuid, username, tenant_id) VALUES (%s, %s, (SELECT id FROM public.api_tenant WHERE schema_name = 'acct' || %s)) RETURNING id", (user_uuid, user_name, account))
+    cursor.execute("INSERT INTO public.management_principal (uuid, username, tenant_id) VALUES (%s, %s, (SELECT id FROM public.api_tenant WHERE tenant_name = 'acct' || %s)) RETURNING id", (user_uuid, user_name, account))
     user_id = cursor.fetchone()[0]
     return user_name, user_id
 


### PR DESCRIPTION
##### Highlights of the PR

1. Trying to fix the following errors that i had seen while running `rbac_populate.py`

```
Traceback (most recent call last):
  File "/home/tally/script2.py", line 189, in <module>
	main()
  File "/home/tally/script2.py", line 170, in main
	rbac_test_data = opl.rbac_populate.doit(rbac_test_data, args, status_data)
  File "/home/venv/src/opl-rhcloud-perf-team/opl/rbac_populate.py", line 252, in doit
	user_name, user_id = create_principal(cursor, account)
  File "/home/venv/src/opl-rhcloud-perf-team/opl/rbac_populate.py", line 175, in create_principal
	cursor.execute("INSERT INTO public.management_principal (uuid, username, tenant_id) VALUES (%s, %s, (SELECT id FROM public.api_tenant WHERE schema_name = 'acct' || %s)) RETURNING id", (user_uuid, user_name, account))
psycopg2.errors.UndefinedColumn: column "schema_name" does not exist
LINE 1: ...6294cca', (SELECT id FROM public.api_tenant WHERE schema_nam...

```