### PR TITLE
adding a delay in verify()

### DIFF
--- a/opl/hbi_utils.py
+++ b/opl/hbi_utils.py
@@ -148,7 +148,7 @@ def verify(args, previous_records, status_data, inventory, collect_info):
             logging.debug(
                 f"Waiting for IDs, attempt {attempt}, remaining {existing_ids}"
             )
-            time.sleep(1)
+            time.sleep(15)
 
     inventory_cursor.close()
 


### PR DESCRIPTION
This delay reduces the number of SELECT calls to Postgres. This avoids locking while running 100,000 hosts.