### PR TITLE
fix HBI cleanup: Truncate cascading tables, too

### DIFF
--- a/opl/hbi_utils.py
+++ b/opl/hbi_utils.py
@@ -296,7 +296,7 @@ def cleanup(args, status_data):
     inventory_cursor = inventory.cursor()
 
     logging.info("Truncating Inventory DB 'hosts' table")
-    inventory_cursor.execute("TRUNCATE hosts")
+    inventory_cursor.execute("TRUNCATE hosts CASCADE")
     inventory.commit()
 
     status_data.set_now("parameters.inventory_db.table_hosts.truncated_at")


### PR DESCRIPTION
error: psycopg2.errors.FeatureNotSupported: cannot truncate a table referenced in a foreign key constraint
DETAIL:  Table "hosts_groups" references "hosts".