### PR TITLE
Generator templates: Add possibility to load jinja2 template from iperf's toolbox in /home/.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,8 @@ Running unit tests
 
     source venv/bin/activate
     python -m pytest
+
+Notes
+------------------
+* Our Jinja2 by default loads templates from the folder where the script `generic.py` is located. 
+  * If no template with a given name is found, the second option is used: the `/home/` folder. That's more useful for temporary changes. For example, if I have a template in iperf in `/home/compliance/mycustomtemplate.j2`, I'll omit the `/home` to use this: `compliance/mycustomtemplate.j2`.

--- a/opl/generators/generic.py
+++ b/opl/generators/generic.py
@@ -28,7 +28,11 @@ class GenericGenerator:
 
         data_dirname = os.path.dirname(__file__)
         self.env = jinja2.Environment(
-            loader=jinja2.FileSystemLoader(data_dirname))
+            loader = jinja2.ChoiceLoader([
+                jinja2.FileSystemLoader(data_dirname),
+                jinja2.FileSystemLoader('/home/')
+            ])
+        )
         self.template = self.env.get_template(self.template_file)
 
         logging.info(f"Created {self}")

--- a/opl/generators/inventory_ingress_puptoo_template_compliance.json.j2
+++ b/opl/generators/inventory_ingress_puptoo_template_compliance.json.j2
@@ -15,7 +15,7 @@
       "system_profile": {
         "owner_id": "{{ owner_id }}",
         "cpu_model": "{{ cpu_model }}",
-        "operating_system": "operating_system": {
+        "operating_system": {
                 "major": 7,
                 "minor": 9,
                 "name": "RHEL"


### PR DESCRIPTION
This adds a second fallback  path to load templates from: it will search the template inside of /home/, too. Previously templates could be loaded only from OPL's `/generators/`, making it harder to make temporary changes.