### PR TITLE
Improves `"opl/cluster_read.py"`

### DIFF
--- a/opl/cluster_read.py
+++ b/opl/cluster_read.py
@@ -82,7 +82,10 @@ class PrometheusMeasurementsPlugin(BasePlugin):
         assert ri.start is not None and ri.end is not None, \
             "We need timerange to approach Prometheus"
         # Get data from Prometheus
-        url = f'{self.host}:{self.port}/api/v1/query_range'
+        if self.host.endswith('.svc'):
+            url = f'{self.host}:{self.port}/api/v1/query_range'
+        else:
+            url = f'{self.host}/api/v1/query_range'
         headers = {
             'Content-Type': 'application/json',
         }

--- a/opl/cluster_read.py
+++ b/opl/cluster_read.py
@@ -82,10 +82,7 @@ class PrometheusMeasurementsPlugin(BasePlugin):
         assert ri.start is not None and ri.end is not None, \
             "We need timerange to approach Prometheus"
         # Get data from Prometheus
-        if self.host.endswith('.svc'):
-            url = f'{self.host}:{self.port}/api/v1/query_range'
-        else:
-            url = f'{self.host}/api/v1/query_range'
+        url = f'{self.host}:{self.port}/api/v1/query_range'
         headers = {
             'Content-Type': 'application/json',
         }

--- a/opl/cluster_read.py
+++ b/opl/cluster_read.py
@@ -250,7 +250,7 @@ class PerformanceInsightsMeasurementPlugin(BasePlugin):
         assert len(response['MetricList'][0]['DataPoints']) > 0, \
             "'DataPoints' needs to be in response"
 
-        points = [ data_point.get('Value', 0) for data_point in response['MetricList'][0]['DataPoints'] ]
+        points = [ data_point['Value'] for data_point in response['MetricList'][0]['DataPoints'] if 'Value' in data_point ]
         stats = data.data_stats(points)
         return name, stats
 

--- a/opl/cluster_read.py
+++ b/opl/cluster_read.py
@@ -248,6 +248,8 @@ class PerformanceInsightsMeasurementPlugin(BasePlugin):
             "'DataPoints' needs to be in response"
 
         points = [ data_point['Value'] for data_point in response['MetricList'][0]['DataPoints'] if 'Value' in data_point ]
+        if len(points) < len(response['MetricList'][0]['DataPoints']):
+            logging.info(f"Value is missing in the AWS PI datapoints, total data points: {len(response['MetricList'][0]['DataPoints'])}, available values: {len(points)}")
         stats = data.data_stats(points)
         return name, stats
 

--- a/opl/cluster_read.py
+++ b/opl/cluster_read.py
@@ -250,7 +250,7 @@ class PerformanceInsightsMeasurementPlugin(BasePlugin):
         assert len(response['MetricList'][0]['DataPoints']) > 0, \
             "'DataPoints' needs to be in response"
 
-        points = [ data_point['Value'] for data_point in response['MetricList'][0]['DataPoints'] ]
+        points = [ data_point.get('Value', 0) for data_point in response['MetricList'][0]['DataPoints'] ]
         stats = data.data_stats(points)
         return name, stats
 


### PR DESCRIPTION
#### Highlights of the PR
1. Adjust prometheus `url` so that clients outside of OpenShift can query the monitoring data
2. Handle `KeyError` exceptions by inserting 0 if the value does not exist for a data point in the RDS-PI-MetricList-DataPoints