### PR TITLE
avoiding flake8 pointing after black formating that results in W503

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-ignore = E501
+ignore = E501,W503
 exclude = .git,__pycache__,venv


### PR DESCRIPTION
CC: @jhutar 
Due to some rules conflict between black formatting and flake8, we need to overlook W503 error after black does the formatting until this is fixed.