### PR TITLE
Fix(inventory_egress): Missing orgid in _get_b64_identity method call, just use account value as that

### DIFF
--- a/opl/generators/inventory_egress.py
+++ b/opl/generators/inventory_egress.py
@@ -66,12 +66,13 @@ class EgressHostsGenerator(opl.generators.generic.GenericGenerator):
             "inventory_id": self._get_uuid(),
             "insights_id": self._get_uuid(),
             "account": account,
+            "orgid": account,
             "os_tree_commit": os_tree_commit,
             "fqdn": self._get_hostname(),
             "installed_packages": self.pg.generate(self.n_packages),
             "yum_repos": self.data["ENABLED_REPOS"]
             + random.sample(self.data["AVAILABLE_REPOS"], 10),  # noqa: W503
-            "b64_identity": self._get_b64_identity(account),
+            "b64_identity": self._get_b64_identity(account, account),
             "msg_type": self.msg_type,
             "machine_id": self._get_rhel_machine_id(),
             "subscription_manager_id": self._get_uuid(),


### PR DESCRIPTION
In Raj's Edge2 [script](https://master-jenkins-csb-perf.apps.ocp-c1.prod.psi.redhat.com/view/Insights_CPT/job/InsightsEdge_runner/1055/console):
```
  File "/home/venv/src/opl-rhcloud-perf-team/opl/generators/inventory_egress.py", line 74, in _data
    "b64_identity": self._get_b64_identity(account),
TypeError: _get_b64_identity() missing 1 required positional argument: 'orgid'

```