### PR TITLE
For edge account and org_id must have same values

### DIFF
--- a/opl/generators/inventory_ingress.py
+++ b/opl/generators/inventory_ingress.py
@@ -58,7 +58,7 @@ class InventoryIngressGenerator(opl.generators.generic.GenericGenerator):
             return [
                 {
                     "account": i["account"],
-                    "orgid": self._get_orgid(),
+                    "orgid": i["account"],
                     "os_tree_commits": i["os_tree_commits"],
                 }
                 for i in self.per_account_data  # because per_account_data is a list not dictionary


### PR DESCRIPTION
Hello @jhutar . This MR is to fix the following error i recorded from inventory logs
```
 raise ValidationException("The org_id in the identity does not match the org_id in the host.")
app.exceptions.ValidationException: The org_id in the identity does not match the org_id in the host.
```
After the change, i was able to successfully produce it to events topic and record a device in edge db.
Let me know if further changes are required.
Thank You!