### PR TITLE
Fix(Kafka_skip_end): Use argument kafka_group instead of hardcoded default

### DIFF
--- a/opl/skip_to_end.py
+++ b/opl/skip_to_end.py
@@ -2,7 +2,6 @@
 
 import logging
 import argparse
-import socket
 import os
 import time
 
@@ -54,7 +53,10 @@ def doit_seek_to_end(kafka_hosts, kafka_timeout, kafka_topic, kafka_group):
 
 def doit(args, status_data):
     doit_seek_to_end(
-        [f"{args.kafka_host}:{args.kafka_port}"], args.kafka_timeout, args.kafka_topic, args.kafka_group
+        [f"{args.kafka_host}:{args.kafka_port}"],
+        args.kafka_timeout,
+        args.kafka_topic,
+        args.kafka_group,
     )
 
     status_data.set("parameters.kafka.seek_topic", args.kafka_topic)

--- a/opl/skip_to_end.py
+++ b/opl/skip_to_end.py
@@ -21,7 +21,7 @@ def doit_seek_to_end(kafka_hosts, kafka_timeout, kafka_topic, kafka_group):
     and static group name, we would have problems when running concurrently
     on multiple pods.
     """
-    logging.info(f"Creating Kafka consumer for {kafka_hosts} in group {KAFKA_GROUP} with timeout {kafka_timeout} ms topic {kafka_topic}")
+    logging.info(f"Creating Kafka consumer for {kafka_hosts} in group {kafka_group} with timeout {kafka_timeout} ms topic {kafka_topic}")
     consumer = KafkaConsumer(
         kafka_topic,
         bootstrap_servers=kafka_hosts,

--- a/opl/skip_to_end.py
+++ b/opl/skip_to_end.py
@@ -12,10 +12,7 @@ from . import args
 from . import skelet
 
 
-KAFKA_GROUP = f"perf-test-{socket.gethostname()}"
-
-
-def doit_seek_to_end(kafka_hosts, kafka_timeout, kafka_topic):
+def doit_seek_to_end(kafka_hosts, kafka_timeout, kafka_topic, kafka_group):
     """
     Create consumer and seek to end
 
@@ -30,7 +27,7 @@ def doit_seek_to_end(kafka_hosts, kafka_timeout, kafka_topic):
         bootstrap_servers=kafka_hosts,
         auto_offset_reset='latest',
         enable_auto_commit=True,
-        group_id=KAFKA_GROUP,
+        group_id=kafka_group,
         session_timeout_ms=50000,
         heartbeat_interval_ms=10000,
         consumer_timeout_ms=kafka_timeout)
@@ -56,7 +53,8 @@ def doit(args, status_data):
     doit_seek_to_end(
         [f"{args.kafka_host}:{args.kafka_port}"],
         args.kafka_timeout,
-        args.kafka_topic)
+        args.kafka_topic,
+        args.kafka_group)
 
     status_data.set('parameters.kafka.seek_topic', args.kafka_topic)
     status_data.set('parameters.kafka.seek_timeout', args.kafka_timeout)


### PR DESCRIPTION
Tested by running it on my -jsmejkal toolbox pod: https://master-jenkins-csb-perf.apps.ocp-c1.prod.psi.redhat.com/job/InsightsCyndi_runner/378/parameters/
Default value set in argument already: https://github.com/redhat-performance/opl/blob/726351e8d31269f3dc0109224bb7d0df10025b4b/opl/args.py#L105