### PR TITLE
Providing timestamp in rfc and added orgid to egress template

### DIFF
--- a/opl/generators/generic.py
+++ b/opl/generators/generic.py
@@ -113,7 +113,11 @@ class GenericGenerator:
 
     def _get_now_iso_z(self):
         return self._get_now_iso().replace("+00:00", "Z")
-
+    
+    def _get_now_rfc(self):
+        rfc_time=datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
+        return (rfc_time.split("T")[0]+" "+rfc_time.split("T")[1]).replace(":00","")
+        
     def _get_tommorow_iso(self):
         return (
             datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
@@ -123,6 +127,9 @@ class GenericGenerator:
     def _get_tommorow_iso_z(self):
         return self._get_tommorow_iso().replace("+00:00", "Z")
 
+    def _get_tommorow_rfc(self):
+        rfc_time_tommorow=(datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)+ datetime.timedelta(days=1)).isoformat()
+        return (rfc_time_tommorow.split("T")[0]+" "+rfc_time_tommorow.split("T")[1]).replace(":00","")
     def _get_ips_macs(self, count):
         ips = ["127.0.0.1"]
         macs = [self._get_mac()]

--- a/opl/generators/generic.py
+++ b/opl/generators/generic.py
@@ -113,11 +113,13 @@ class GenericGenerator:
 
     def _get_now_iso_z(self):
         return self._get_now_iso().replace("+00:00", "Z")
-    
+
     def _get_now_rfc(self):
-        rfc_time=datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
-        return ((rfc_time.replace("T"," ")).replace(":00",""))
-        
+        rfc_time = (
+            datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
+        )
+        return (rfc_time.replace("T", " ")).replace(":00", "")
+
     def _get_tommorow_iso(self):
         return (
             datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
@@ -128,8 +130,12 @@ class GenericGenerator:
         return self._get_tommorow_iso().replace("+00:00", "Z")
 
     def _get_tommorow_rfc(self):
-        rfc_time_tommorow=(datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)+ datetime.timedelta(days=1)).isoformat()
-        return ((rfc_time_tommorow.replace("T"," ")).replace(":00",""))
+        rfc_time_tommorow = (
+            datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
+            + datetime.timedelta(days=1)
+        ).isoformat()
+        return (rfc_time_tommorow.replace("T", " ")).replace(":00", "")
+
     def _get_ips_macs(self, count):
         ips = ["127.0.0.1"]
         macs = [self._get_mac()]

--- a/opl/generators/generic.py
+++ b/opl/generators/generic.py
@@ -116,7 +116,7 @@ class GenericGenerator:
     
     def _get_now_rfc(self):
         rfc_time=datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
-        return (rfc_time.split("T")[0]+" "+rfc_time.split("T")[1]).replace(":00","")
+        return ((rfc_time.replace("T"," ")).replace(":00",""))
         
     def _get_tommorow_iso(self):
         return (
@@ -129,7 +129,7 @@ class GenericGenerator:
 
     def _get_tommorow_rfc(self):
         rfc_time_tommorow=(datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)+ datetime.timedelta(days=1)).isoformat()
-        return (rfc_time_tommorow.split("T")[0]+" "+rfc_time_tommorow.split("T")[1]).replace(":00","")
+        return ((rfc_time_tommorow.replace("T"," ")).replace(":00",""))
     def _get_ips_macs(self, count):
         ips = ["127.0.0.1"]
         macs = [self._get_mac()]

--- a/opl/generators/inventory_egress.py
+++ b/opl/generators/inventory_egress.py
@@ -79,7 +79,7 @@ class EgressHostsGenerator(opl.generators.generic.GenericGenerator):
             "ipv6_addr": self._get_ipv6(),
             "mac_addr": self._get_mac(),
             "request_id": self._get_uuid(),
-            "nowz": self._get_now_iso_z(),
-            "tommorowz": self._get_tommorow_iso_z(),
+            "nowz": self._get_now_rfc(),
+            "tommorowz": self._get_tommorow_rfc(),
             "s3_presigned_url": self.s3_presigned_url,
         }

--- a/opl/generators/inventory_egress_template.json.j2
+++ b/opl/generators/inventory_egress_template.json.j2
@@ -1,6 +1,7 @@
 {
   "host": {
     "account": "{{ account }}",
+    "orgid": "{{ orgid }}",
     "ansible_host": null,
     "bios_uuid": "{{ bios_uuid }}",
     "created": "{{ nowz }}",


### PR DESCRIPTION
Patchman expects now and tommorow timestamp to be provided in rfc format. This PR add two functions to generate the same. Egress template is also missing org_id, so this PR also adds that.