### PR TITLE
Upload Comparison result using multiple decision type

### DIFF
--- a/opl/investigator/config.py
+++ b/opl/investigator/config.py
@@ -90,3 +90,12 @@ def load_config(conf, fp):
         conf.decisions_es_index = data["decisions"]["es_index"]
     if conf.decisions_type == "csv":
         conf.decisions_filename = data["decisions"]["filename"]
+
+    decision_type = conf.decisions_type.split(',')
+    for d_type in decision_type:
+        if d_type.strip() == "elasticsearch":
+            conf.decisions_es_server = data["decisions"]["es_server"]
+            assert not conf.decisions_es_server.endswith("/")
+            conf.decisions_es_index = data["decisions"]["es_index"]
+        if d_type.strip() == "csv":
+            conf.decisions_filename = data["decisions"]["filename"]

--- a/opl/investigator/config.py
+++ b/opl/investigator/config.py
@@ -91,7 +91,7 @@ def load_config(conf, fp):
     if conf.decisions_type == "csv":
         conf.decisions_filename = data["decisions"]["filename"]
 
-    decision_type = conf.decisions_type.split(',')
+    decision_type = conf.decisions_type.split(",")
     for d_type in decision_type:
         if d_type.strip() == "elasticsearch":
             conf.decisions_es_server = data["decisions"]["es_server"]

--- a/opl/investigator/config.py
+++ b/opl/investigator/config.py
@@ -91,11 +91,11 @@ def load_config(conf, fp):
     if conf.decisions_type == "csv":
         conf.decisions_filename = data["decisions"]["filename"]
 
-    decision_type = conf.decisions_type.split(",")
-    for d_type in decision_type:
-        if d_type.strip() == "elasticsearch":
+    conf.decisions_type = [d_type.strip() for d_type in conf.decisions_type.split(",")]
+    for d_type in conf.decisions_type:
+        if d_type == "elasticsearch":
             conf.decisions_es_server = data["decisions"]["es_server"]
             assert not conf.decisions_es_server.endswith("/")
             conf.decisions_es_index = data["decisions"]["es_index"]
-        if d_type.strip() == "csv":
+        if d_type == "csv":
             conf.decisions_filename = data["decisions"]["filename"]

--- a/opl/pass_or_fail.py
+++ b/opl/pass_or_fail.py
@@ -198,12 +198,14 @@ def main():
         get_stats(info_all, "method")
 
     if not args.dry_run:
-        if args.decisions_type == "elasticsearch":
-            opl.investigator.elasticsearch_decisions.store(
-                args.decisions_es_server, args.decisions_es_index, info_all
-            )
-        if args.decisions_type == "csv":
-            opl.investigator.csv_decisions.store(args.decisions_filename, info_all)
+        decision_type = args.decisions_type.split(",")
+        for d_type in decision_type:
+            if d_type.strip() == "elasticsearch":
+                opl.investigator.elasticsearch_decisions.store(
+                    args.decisions_es_server, args.decisions_es_index, info_all
+                )
+            if d_type.strip() == "csv":
+                opl.investigator.csv_decisions.store(args.decisions_filename, info_all)
 
     if not args.dry_run:
         if exit_code == 0:

--- a/opl/pass_or_fail.py
+++ b/opl/pass_or_fail.py
@@ -198,13 +198,12 @@ def main():
         get_stats(info_all, "method")
 
     if not args.dry_run:
-        decision_type = args.decisions_type.split(",")
-        for d_type in decision_type:
-            if d_type.strip() == "elasticsearch":
+        for d_type in args.decisions_type:
+            if d_type == "elasticsearch":
                 opl.investigator.elasticsearch_decisions.store(
                     args.decisions_es_server, args.decisions_es_index, info_all
                 )
-            if d_type.strip() == "csv":
+            if d_type == "csv":
                 opl.investigator.csv_decisions.store(args.decisions_filename, info_all)
 
     if not args.dry_run:


### PR DESCRIPTION
PR #96

This PR deals with allowing multiple Decision types. 

Earlier either we were able to get our results in the form of Decision.csv file or upload them to elasticsearch. With this change we will be able to gather results in csv format as well as send them to elasticsearch.