### PR TITLE
Add verify = false to fix SSL errors

### DIFF
--- a/core/opl/shovel.py
+++ b/core/opl/shovel.py
@@ -184,6 +184,7 @@ class pluginHorreum:
             response = requests.get(
                 f"{self.args.horreum_host}/api/test/byName/{self.args.test_name_horreum}",
                 headers=headers,
+                verify=False
             )
             test_id = json.load(response.text)["id"]
             filter_data = {f"{self.args.test_matcher}": f"{test_matcher}"}
@@ -191,6 +192,7 @@ class pluginHorreum:
                 f"{self.args.horreum_host}/api/dataset/list/{test_id}",
                 headers=headers,
                 params={"filter": json.dumps(filter_data)},
+                verify=False
             )
             datasets = response.json().get("datasets", [])
             if len(datasets) > 0:

--- a/opl/shovel.py
+++ b/opl/shovel.py
@@ -184,6 +184,7 @@ class pluginHorreum:
             response = requests.get(
                 f"{self.args.horreum_host}/api/test/byName/{self.args.test_name_horreum}",
                 headers=headers,
+                verify=False
             )
             test_id = json.load(response.text)["id"]
             filter_data = {f"{self.args.test_matcher}": f"{test_matcher}"}
@@ -191,6 +192,7 @@ class pluginHorreum:
                 f"{self.args.horreum_host}/api/dataset/list/{test_id}",
                 headers=headers,
                 params={"filter": json.dumps(filter_data)},
+                verify=False
             )
             datasets = response.json().get("datasets", [])
             if len(datasets) > 0:


### PR DESCRIPTION
Hi @jhutar , i was seeing `SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:` errors in the job.

I think adding verify = false would fix it, but is it the right approach? 