### PR TITLE
fix(status_data): Add missing deepdiff dependency numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setuptools.setup(
         "requests",
         "tabulate",
         "deepdiff",
+        "numpy",
         # Other package dependencies
     ],
     extras_require={


### PR DESCRIPTION

Got this error:
```
Traceback (most recent call last):
  File "/home/jenkins/workspace/InsightsInventoryXjoinlessPerfTest_runner/venv/bin/status_data.py", line 5, in <module>
    from opl.status_data import main
  File "/home/jenkins/workspace/InsightsInventoryXjoinlessPerfTest_runner/venv/src/opl-rhcloud-perf-team/opl/status_data.py", line 11, in <module>
    import deepdiff
  File "/home/jenkins/workspace/InsightsInventoryXjoinlessPerfTest_runner/venv/lib64/python3.12/site-packages/deepdiff/__init__.py", line 10, in <module>
    from .diff import DeepDiff
  File "/home/jenkins/workspace/InsightsInventoryXjoinlessPerfTest_runner/venv/lib64/python3.12/site-packages/deepdiff/diff.py", line 30, in <module>
    from deepdiff.distance import DistanceMixin, logarithmic_similarity
  File "/home/jenkins/workspace/InsightsInventoryXjoinlessPerfTest_runner/venv/lib64/python3.12/site-packages/deepdiff/distance.py", line 1, in <module>
    import numpy as np
ModuleNotFoundError: No module named 'numpy'
```
Tried to verify it fixes it by installing OPL in editable mode, entering python console and importing numpy and deepdiff. Both work.