### PR TITLE
fix(KONFLUX-4956): redact sensitive header info from logging

### DIFF
--- a/core/opl/cluster_read.py
+++ b/core/opl/cluster_read.py
@@ -38,12 +38,12 @@ def execute(command):
 
 def redact_sensitive_headers(data: dict):
     # Lower-case list of sensitive data in header
-    sensitive_headers = ['authorization', 'set-cookie', 'x-api-key', 'cookie']
+    sensitive_headers = ["authorization", "set-cookie", "x-api-key", "cookie"]
 
     redacted_headers = {}
     for header, value in data.items():
         if header.lower() in sensitive_headers:
-            redacted_headers[header] = '<REDACTED>'
+            redacted_headers[header] = "<REDACTED>"
         else:
             redacted_headers[header] = value
     return redacted_headers

--- a/core/opl/cluster_read.py
+++ b/core/opl/cluster_read.py
@@ -36,14 +36,27 @@ def execute(command):
     return result
 
 
+def redact_sensitive_headers(data: dict):
+    # Lower-case list of sensitive data in header
+    sensitive_headers = ['authorization', 'set-cookie', 'x-api-key', 'cookie']
+
+    redacted_headers = {}
+    for header, value in data.items():
+        if header.lower() in sensitive_headers:
+            redacted_headers[header] = '<REDACTED>'
+        else:
+            redacted_headers[header] = value
+    return redacted_headers
+
+
 def _debug_response(r):
     """
     Print various info about the requests response. Should be called when
     request failed
     """
     logging.error("URL = %s" % r.url)
-    logging.error("Request headers = %s" % r.request.headers)
-    logging.error("Response headers = %s" % r.headers)
+    logging.error("Request headers = %s" % redact_sensitive_headers(r.request.headers))
+    logging.error("Response headers = %s" % redact_sensitive_headers(r.headers))
     logging.error("Response status code = %s" % r.status_code)
     logging.error("Response content = %s" % r.content[:500])
     raise Exception("Request failed")

--- a/opl/cluster_read.py
+++ b/opl/cluster_read.py
@@ -38,12 +38,12 @@ def execute(command):
 
 def redact_sensitive_headers(data: dict):
     # Lower-case list of sensitive data in header
-    sensitive_headers = ['authorization', 'set-cookie', 'x-api-key', 'cookie']
+    sensitive_headers = ["authorization", "set-cookie", "x-api-key", "cookie"]
 
     redacted_headers = {}
     for header, value in data.items():
         if header.lower() in sensitive_headers:
-            redacted_headers[header] = '<REDACTED>'
+            redacted_headers[header] = "<REDACTED>"
         else:
             redacted_headers[header] = value
     return redacted_headers

--- a/opl/cluster_read.py
+++ b/opl/cluster_read.py
@@ -36,14 +36,27 @@ def execute(command):
     return result
 
 
+def redact_sensitive_headers(data: dict):
+    # Lower-case list of sensitive data in header
+    sensitive_headers = ['authorization', 'set-cookie', 'x-api-key', 'cookie']
+
+    redacted_headers = {}
+    for header, value in data.items():
+        if header.lower() in sensitive_headers:
+            redacted_headers[header] = '<REDACTED>'
+        else:
+            redacted_headers[header] = value
+    return redacted_headers
+
+
 def _debug_response(r):
     """
     Print various info about the requests response. Should be called when
     request failed
     """
     logging.error("URL = %s" % r.url)
-    logging.error("Request headers = %s" % r.request.headers)
-    logging.error("Response headers = %s" % r.headers)
+    logging.error("Request headers = %s" % redact_sensitive_headers(r.request.headers))
+    logging.error("Response headers = %s" % redact_sensitive_headers(r.headers))
     logging.error("Response status code = %s" % r.status_code)
     logging.error("Response content = %s" % r.content[:500])
     raise Exception("Request failed")


### PR DESCRIPTION
This PR adds a preprocessing to mask sensitive information from headers (like Authorization,Set-Cookie, X-API-Key, Cookie) before logging it into debug output. The header values are replaced with keyword `<REDACTED>`.

Log Output after masking:
```
Exception: Request failed
2024-10-10 11:29:31,482 root MainThread ERROR URL = https://thanos-querier-openshift-monitoring.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com:443/api/v1/query_range?query=sum%28+rate%28container_network_transmit_packets_dropped_total%7Bnamespace%3D%27tekton-results%27%2C+pod%3D~%27tekton-results-watcher-.%2A%27%7D%5B80s%5D%29+%2B+rate%28container_network_receive_packets_dropped_total%7Bnamespace%3D%27tekton-results%27%2C+pod%3D~%27tekton-results-watcher-.%2A%27%7D%5B80s%5D%29+%29&step=80&start=1728378208.0&end=1728384371.0
2024-10-10 11:29:31,482 root MainThread ERROR Request headers = {'User-Agent': 'python-requests/2.32.3', 'Accept-Encoding': 'gzip, deflate, br', 'Accept': '*/*', 'Connection': 'keep-alive', 'Content-Type': 'application/json', 'Authorization': '<REDACTED>'}
2024-10-10 11:29:31,482 root MainThread ERROR Response headers = {'content-type': 'text/plain; charset=utf-8', 'x-content-type-options': 'nosniff', 'content-length': '13', 'date': 'Thu, 10 Oct 2024 11:29:31 GMT', 'strict-transport-security': 'max-age=31536000;preload', 'set-cookie': '<REDACTED>'}
```