### PR TITLE
fix compliance&cyndi generator template: remove host_type altogether as the validation was changed to either allow host_type='edge' or None, nothing else.

### DIFF
--- a/opl/generators/inventory_ingress_puptoo_template_compliance.json.j2
+++ b/opl/generators/inventory_ingress_puptoo_template_compliance.json.j2
@@ -78,7 +78,6 @@
         "satellite_managed": "false",
         "is_marketplace": {{ is_marketplace }},
         "rhc_client_id": "{{ rhc_client_id }}",
-        "host_type": "not_edge",
         "greenboot_status": "green",
         "greenboot_fallback_detected": "true",
         "rhc_config_state": "{{ rhc_config_state }}",


### PR DESCRIPTION


[2024-11-07 14:57:50,292] [8] [140518771590976] [inventory.app.queue.host_mq] [ERROR] Validation error while adding or updating host: {'system_profile': ["System profile does not conform to schema.\n'not_ed-ge' is not one of ['edge']\n\nFailed validating 'enum' in schema['properties']['host_type']:\n {'type': 'string',\n 'enum': ['edge'],\n 'maxLength': 4,\n 'description': 'Indicates the type of host.',\n 'example': 'edge, None'}\n\nOn instance['host_type']:\n 'not_ed-ge'"]}; Invalid data: {'system_profile': {'owner_id': 'b783079b-4aa5-4cdd-af70-8f6883c51419', 'cpu_model': 'Intel(R) I7(R) CPU I7-10900k 0 @ 4.90GHz', 'operating_system': {'major': 7, 'minor': 9, 'name': 'RHEL'}, 'installed_packages': ['python3-pip-0:9.0.3-7.el7_8.noarch', 'scrub-0:2.5.2-5.el7.x86_64', 'opensm-0:3.3.20-2.el7.x86_64', 'xcb-util-renderutil-0:0.3.9-3.el7.i686', 'msv-msv-1:2013.5.1-7.el7.noarch', 'hunspell-be-0:1.1-7.el7.noarch', 'pyOpenSSL-0:0.13.1-3.el7.x86_64', 'linuxconsoletools-0:1.4.5-3.el7.x86_64', 'k...