### PR TITLE
fix typing issue

### DIFF
--- a/opl/s3_tools.py
+++ b/opl/s3_tools.py
@@ -1,7 +1,7 @@
 import logging
 import boto3
 import botocore.client
-from typing import List, Dict
+from typing import List, Dict, Union
 
 
 def connect(s3_conf: Dict) -> boto3.resource:
@@ -51,8 +51,8 @@ def get_presigned_url(s3_resource, bucket, remote_name):
 
 
 def delete_files(
-    s3_resource: boto3.resource, bucket_name: str, file_paths: str | List
-) -> Dict | bool:
+    s3_resource: boto3.resource, bucket_name: str, file_paths: Union[str, List[str]]
+) -> Union[Dict, bool]:
     """
     Delete s3-objets from s3 bucket
     Args:


### PR DESCRIPTION
## Error:
```bash
s3_resource: boto3.resource, bucket_name: str, file_paths: str | List
TypeError: unsupported operand type(s) for |: 'type' and '_SpecialGenericAlias'
```
## How to reproduce
Run function `delete_files` from opl/s3_tools.py script with `python3.9`

## Fix:
Use `typing.Union` instead of `|` because `|` is not supported in python versions < 3.10 

ref: https://docs.python.org/3/library/typing.html#typing.Union 

| Syntax                       |Python 3.9 and below | Python 3.10+	   | Python 3.12+   |
|-----------------------------|--------------------------------|---------------------------|----------------------|
| Union[str, List[str]] | ✅ Supported              | ✅ Supported	    | ✅ Supported |
| `str	                      | list[str]`	                        | ❌ Not supported | ✅ Supported |
