### PR TITLE
feat: Add percentile95 to data_stats

### DIFF
--- a/core/opl/data.py
+++ b/core/opl/data.py
@@ -209,6 +209,7 @@ def data_stats(data):
         q25 = percentile(data, 25)
         q75 = percentile(data, 75)
         q90 = percentile(data, 90)
+        q95 = percentile(data, 95)
         q99 = percentile(data, 99)
         q999 = percentile(data, 99.9)
         return {
@@ -229,6 +230,7 @@ def data_stats(data):
             "percentile25": q25,
             "percentile75": q75,
             "percentile90": q90,
+            "percentile95": q95,
             "percentile99": q99,
             "percentile999": q999,
             "iqr": q75 - q25,

--- a/opl/data.py
+++ b/opl/data.py
@@ -209,6 +209,7 @@ def data_stats(data):
         q25 = percentile(data, 25)
         q75 = percentile(data, 75)
         q90 = percentile(data, 90)
+        q95 = percentile(data, 95)
         q99 = percentile(data, 99)
         q999 = percentile(data, 99.9)
         return {
@@ -229,6 +230,7 @@ def data_stats(data):
             "percentile25": q25,
             "percentile75": q75,
             "percentile90": q90,
+            "percentile95": q95,
             "percentile99": q99,
             "percentile999": q999,
             "iqr": q75 - q25,

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -16,6 +16,7 @@ class TestSkelet(unittest.TestCase):
         self.assertEqual(stats["range"], 2)
         self.assertEqual(stats["percentile25"], 0.75)
         self.assertEqual(stats["percentile75"], 1.25)
+        self.assertEqual(stats["percentile95"], 2.0)
         self.assertEqual(stats["iqr"], 0.5)
 
     def test_data_stats_empty(self):


### PR DESCRIPTION
## Summary

- Adds `percentile95` computation to `data_stats` in both `opl/data.py` and `core/opl/data.py`, alongside the existing `percentile25`, `percentile75`, `percentile90`, `percentile99`, and `percentile999` helpers
- Adds a corresponding test assertion in `test_data_stats`

## Test plan

- [x] Verify `stats["percentile95"]` is returned by `data_stats` for numeric input
- [x] Run `python3 -m pytest tests/test_data.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)