### PR TITLE
feat(cluster_read): Batch Grafana queries via look-ahead in iterator

### DIFF
--- a/core/opl/cluster_read.py
+++ b/core/opl/cluster_read.py
@@ -13,10 +13,10 @@ import boto3
 import urllib3
 import tempfile
 
-from . import data
-from . import date
-from . import status_data
-from . import retry
+from opl import data
+from opl import date
+from opl import status_data
+from opl import retry
 
 
 def execute(command):

--- a/core/opl/cluster_read.py
+++ b/core/opl/cluster_read.py
@@ -191,11 +191,54 @@ class PrometheusMeasurementsPlugin(BasePlugin):
 
 
 class GrafanaMeasurementsPlugin(BasePlugin):
+    def __init__(self, args):
+        super().__init__(args)
+        self._session = requests.Session()
+
+    @property
+    def batch_size(self):
+        return getattr(self.args, "grafana_chunk_size", 50)
+
+    @staticmethod
+    def _empty_timerange(ri):
+        return (
+            ri.start is None
+            or ri.end is None
+            or int(ri.start.timestamp()) == int(ri.end.timestamp())
+        )
+
     def _sanitize_target(self, target):
         target = target.replace("$Node", self.args.grafana_node)
         target = target.replace("$Interface", self.args.grafana_interface)
         target = target.replace("$Cloud", self.args.grafana_prefix)
         return target
+
+    def _fetch_targets(self, ri, targets):
+        """Fetch one or more targets in a single Graphite render request."""
+        headers = {"Accept": "application/json, text/plain, */*"}
+        if self.args.grafana_token is not None:
+            headers["Authorization"] = "Bearer %s" % self.args.grafana_token
+        params = {
+            "target": targets,
+            "from": int(ri.start.timestamp()),
+            "until": round(ri.end.timestamp()),
+            "format": "json",
+        }
+        url = (
+            f"{self.args.grafana_host}:{self.args.grafana_port}"
+            f"/api/datasources/proxy/{self.args.grafana_datasource}/render"
+        )
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        r = self._session.post(
+            url=url, headers=headers, data=params, timeout=60, verify=False
+        )
+        if (
+            not r.ok
+            or r.headers["Content-Type"] != "application/json"
+            or r.json() == []
+        ):
+            _debug_response(r)
+        return r.json()
 
     @retry.retry_on_traceback(max_attempts=10, wait_seconds=1)
     def measure(
@@ -209,51 +252,90 @@ class GrafanaMeasurementsPlugin(BasePlugin):
         assert (
             ri.start is not None and ri.end is not None
         ), "We need timerange to approach Grafana"
-        if ri.start.strftime("%s") == ri.end.strftime("%s"):
+        if self._empty_timerange(ri):
             return name, None
 
-        # Metadata for the request
-        headers = {
-            "Accept": "application/json, text/plain, */*",
+        response = self._fetch_targets(ri, [self._sanitize_target(grafana_target)])
+        logging.debug("Response: %s" % response)
+
+        points = [float(i[0]) for i in response[0]["datapoints"] if i[0] is not None]
+        item = {
+            "grafana_enritchment": grafana_enritchment,
+            "grafana_include_vars": grafana_include_vars,
         }
-        if self.args.grafana_token is not None:
-            headers["Authorization"] = "Bearer %s" % self.args.grafana_token
-        params = {
-            "target": [self._sanitize_target(grafana_target)],
-            "from": int(ri.start.timestamp()),
-            "until": round(ri.end.timestamp()),
-            "format": "json",
-        }
-        url = f"{self.args.grafana_host}:{self.args.grafana_port}/api/datasources/proxy/{self.args.grafana_datasource}/render"
+        stats = self._apply_item_extras(data.data_stats(points), item)
 
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-        r = requests.post(
-            url=url, headers=headers, params=params, timeout=60, verify=False
-        )
-        if (
-            not r.ok
-            or r.headers["Content-Type"] != "application/json"
-            or r.json() == []
-        ):
-            _debug_response(r)
-        logging.debug("Response: %s" % r.json())
+        return name, stats
 
-        points = [float(i[0]) for i in r.json()[0]["datapoints"] if i[0] is not None]
-        stats = data.data_stats(points)
+    def _apply_item_extras(self, stats, item):
+        """Apply per-item enritchment and variables to computed stats."""
+        if stats is None:
+            return stats
 
-        # Add user defined data to the computed stats
-        if grafana_enritchment is not None and grafana_enritchment != {}:
-            stats["enritchment"] = grafana_enritchment
+        enritchment = item.get("grafana_enritchment", {})
+        if enritchment:
+            stats["enritchment"] = enritchment
 
-        # If requested, add info about what variables were used to the computed stats
-        if grafana_include_vars:
+        if item.get("grafana_include_vars", False):
             stats["variables"] = {
                 "$Node": self.args.grafana_node,
                 "$Interface": self.args.grafana_interface,
                 "$Cloud": self.args.grafana_prefix,
             }
 
-        return name, stats
+        return stats
+
+    def _measure_batched(self, ri, config_items):
+        """Fetch multiple Grafana items in a single HTTP request.
+
+        We rely on Graphite preserving request order here.
+        A malformed response that silently omits an interior target
+        could cause positional mismatches for later items.
+        """
+        targets = [
+            self._sanitize_target(item["grafana_target"]) for item in config_items
+        ]
+        response = self._fetch_targets(ri, targets)
+
+        results = []
+        for idx, item in enumerate(config_items):
+            if idx < len(response):
+                points = [
+                    float(p[0]) for p in response[idx]["datapoints"] if p[0] is not None
+                ]
+                stats = self._apply_item_extras(data.data_stats(points), item)
+            else:
+                stats = self._apply_item_extras(data.data_stats([]), item)
+            results.append((item["name"], stats))
+
+        logging.debug(f"Batched {len(results)} Grafana targets in one request")
+        return results
+
+    def measure_many(self, ri, config_items):
+        """Execute a group of Grafana items with batch-first, per-target-fallback.
+
+        Tries a single batched HTTP request for all items. On failure,
+        degrades to individual measure() calls (each with its own retry)
+        to isolate failures per target.
+        """
+        if self._empty_timerange(ri):
+            return [(item["name"], None) for item in config_items]
+
+        try:
+            return self._measure_batched(ri, config_items)
+        except Exception as e:
+            logging.warning(
+                f"Batch request failed ({e}), falling back to "
+                f"individual queries for {len(config_items)} targets"
+            )
+            results = []
+            for item in config_items:
+                try:
+                    results.append(self.measure(ri, **item))
+                except Exception as e2:
+                    logging.exception(f"Failed to measure {item['name']}: {e2}")
+                    results.append((None, None))
+            return results
 
     @staticmethod
     def add_args(parser):
@@ -263,8 +345,8 @@ class GrafanaMeasurementsPlugin(BasePlugin):
         parser.add_argument(
             "--grafana-chunk-size",
             type=int,
-            default=10,
-            help="How many metrices to obtain from Grafana at one request",
+            default=50,
+            help="How many metrics to obtain from Grafana in one request",
         )
         parser.add_argument(
             "--grafana-port",
@@ -540,6 +622,7 @@ class RequestedInfo:
         self.sd = sd
 
         self._index = 0  # which config item are we processing?
+        self._batch_buffer = []  # buffered results from a batched request
         self._token = None  # OCP token - we will take it from `oc whoami -t` if needed
         self.measurement_plugins = (
             {}
@@ -569,34 +652,59 @@ class RequestedInfo:
 
     def __next__(self):
         """
-        Gives tuple of key and value for every item in the config file
+        Gives tuple of key and value for every item in the config file.
+
+        Plugins that implement measure_many() get consecutive items of
+        the same type grouped and executed in a single call. Results are
+        buffered and yielded one at a time.
         """
+        # Drain buffer from a previous batch
+        if self._batch_buffer:
+            return self._batch_buffer.pop(0)
+
         i = self._index
-        self._index += 1
-        if i < len(self.config):
-            if self._find_plugin(self.config[i].keys()):
-                instance = self._find_plugin(self.config[i].keys())
-                name = list(self.config[i].keys())[1]
-                try:
-                    if name == "log_source_command":
-                        output = instance.measure(self, self.config[i])
-                    else:
-                        output = instance.measure(self, **self.config[i])
-                except NoDataException as e:
-                    logging.warning(
-                        f"Failed to measure {self.config[i]['name']}: {e}"
-                    )
-                    output = (None, None)
-                except Exception as e:
-                    logging.exception(
-                        f"Failed to measure {self.config[i]['name']}: {e}"
-                    )
-                    output = (None, None)
-                return output
-            else:
-                raise Exception(f"Unknown config '{self.config[i]}'")
-        else:
+        if i >= len(self.config):
             raise StopIteration
+
+        instance = self._find_plugin(self.config[i].keys())
+        if not instance:
+            self._index += 1
+            raise Exception(f"Unknown config '{self.config[i]}'")
+
+        # Group consecutive items handled by the same plugin if it
+        # supports measure_many()
+        if hasattr(instance, "measure_many") and self.start and self.end:
+            chunk_size = getattr(instance, "batch_size", 10)
+            chunk_items = []
+            j = i
+            while (
+                j < len(self.config)
+                and self._find_plugin(self.config[j].keys()) is instance
+                and len(chunk_items) < chunk_size
+            ):
+                chunk_items.append(self.config[j])
+                j += 1
+            self._index = j
+
+            results = instance.measure_many(self, chunk_items)
+            self._batch_buffer = results[1:]
+            return results[0]
+
+        # Non-Grafana item: process individually (unchanged)
+        self._index += 1
+        name = list(self.config[i].keys())[1]
+        try:
+            if name == "log_source_command":
+                output = instance.measure(self, self.config[i])
+            else:
+                output = instance.measure(self, **self.config[i])
+        except NoDataException as e:
+            logging.warning(f"Failed to measure {self.config[i]['name']}: {e}")
+            output = (None, None)
+        except Exception as e:
+            logging.exception(f"Failed to measure {self.config[i]['name']}: {e}")
+            output = (None, None)
+        return output
 
 
 def doit(args):

--- a/tests/test_cluster_read.py
+++ b/tests/test_cluster_read.py
@@ -170,13 +170,7 @@ class TestRequestedInfo(unittest.TestCase):
         self.assertEqual(k, "somevalue")
         self.assertEqual(v, "Hello world")
         sd.set(k, v)
-
-        k, v = next(ri)
-        self.assertEqual(k, "mycopyfrom_exists")
-        self.assertEqual(v, "Hello world")
-        k, v = next(ri)
-        self.assertEqual(k, "mycopyfrom_missing")
-        self.assertEqual(v, None)
+        self._assert_copy_from_pair(ri)
 
     def test_copy_from_previous(self):
         string = """
@@ -195,6 +189,9 @@ class TestRequestedInfo(unittest.TestCase):
               copy_from: somevalue_that_does_not_exist
         """
         ri = opl.cluster_read.RequestedInfo(string, sd=sd)
+        self._assert_copy_from_pair(ri)
+
+    def _assert_copy_from_pair(self, ri):
         k, v = next(ri)
         self.assertEqual(k, "mycopyfrom_exists")
         self.assertEqual(v, "Hello world")
@@ -215,6 +212,24 @@ class TestRequestedInfo(unittest.TestCase):
 
 
 class TestGrafanaPlugin(unittest.TestCase):
+    simple_grafana_string = """
+        - name: measurement.load
+          grafana_target: $Cloud.$Node.load.load.shortterm
+    """
+
+    simple_grafana_variables_string = """
+        - name: measurement.load
+          grafana_target: $Cloud.$Node.load.load.shortterm
+          grafana_include_vars: true
+    """
+
+    simple_grafana_enritchment_string = """
+        - name: measurement.load
+          grafana_target: $Cloud.$Node.load.load.shortterm
+          grafana_enritchment:
+            hello: world
+            answer: 42
+    """
 
     mock_post_get_load_simple = {
         "mock": {
@@ -248,26 +263,7 @@ class TestGrafanaPlugin(unittest.TestCase):
 
     @responses.activate
     def test_basic(self):
-        # Configure mock
-        responses.add(
-            **self.mock_post_get_load_simple["mock"],
-        )
-
-        # Configure the request we are going to make
-        string = """
-            - name: measurement.load
-              grafana_target: $Cloud.$Node.load.load.shortterm
-        """
-
-        # Actual test using the mock
-        ri = opl.cluster_read.RequestedInfo(
-            string,
-            start=self.mock_post_get_load_simple["start"],
-            end=self.mock_post_get_load_simple["end"],
-            args=self.mock_post_get_load_simple["args"],
-        )
-        k, v = next(ri)
-        self.assertEqual(k, "measurement.load")
+        v = self._get_simple_measurement()
         self.assertEqual(int(v["min"]), 5)
         self.assertEqual(int(v["mean"]), 10)
         self.assertEqual(int(v["median"]), 10)
@@ -278,27 +274,7 @@ class TestGrafanaPlugin(unittest.TestCase):
 
     @responses.activate
     def test_added_variables(self):
-        # Configure mock
-        responses.add(
-            **self.mock_post_get_load_simple["mock"],
-        )
-
-        # Configure the request we are going to make
-        string = """
-            - name: measurement.load
-              grafana_target: $Cloud.$Node.load.load.shortterm
-              grafana_include_vars: true
-        """
-
-        # Actual test using the mock
-        ri = opl.cluster_read.RequestedInfo(
-            string,
-            start=self.mock_post_get_load_simple["start"],
-            end=self.mock_post_get_load_simple["end"],
-            args=self.mock_post_get_load_simple["args"],
-        )
-        k, v = next(ri)
-        self.assertEqual(k, "measurement.load")
+        v = self._get_simple_measurement(self.simple_grafana_variables_string)
         self.assertEqual(int(v["mean"]), 10)
         self.assertEqual(v["variables"]["$Node"], "node001_example_com")
         self.assertEqual(v["variables"]["$Interface"], "interface-enp2s0")
@@ -307,33 +283,26 @@ class TestGrafanaPlugin(unittest.TestCase):
 
     @responses.activate
     def test_added_enritchment(self):
-        # Configure mock
-        responses.add(
-            **self.mock_post_get_load_simple["mock"],
-        )
-
-        # Configure the request we are going to make
-        string = """
-            - name: measurement.load
-              grafana_target: $Cloud.$Node.load.load.shortterm
-              grafana_enritchment:
-                hello: world
-                answer: 42
-        """
-
-        # Actual test using the mock
-        ri = opl.cluster_read.RequestedInfo(
-            string,
-            start=self.mock_post_get_load_simple["start"],
-            end=self.mock_post_get_load_simple["end"],
-            args=self.mock_post_get_load_simple["args"],
-        )
-        k, v = next(ri)
-        self.assertEqual(k, "measurement.load")
+        v = self._get_simple_measurement(self.simple_grafana_enritchment_string)
         self.assertEqual(int(v["mean"]), 10)
         self.assertEqual(v["enritchment"]["hello"], "world")
         self.assertEqual(v["enritchment"]["answer"], 42)
         self.assertNotIn("variables", v)
+
+    def _make_simple_requested_info(self, string=None):
+        responses.add(**self.mock_post_get_load_simple["mock"])
+        return opl.cluster_read.RequestedInfo(
+            string or self.simple_grafana_string,
+            start=self.mock_post_get_load_simple["start"],
+            end=self.mock_post_get_load_simple["end"],
+            args=self.mock_post_get_load_simple["args"],
+        )
+
+    def _get_simple_measurement(self, string=None):
+        ri = self._make_simple_requested_info(string)
+        k, v = next(ri)
+        self.assertEqual(k, "measurement.load")
+        return v
 
     mock_post_get_batch = {
         "mock": {

--- a/tests/test_cluster_read.py
+++ b/tests/test_cluster_read.py
@@ -6,6 +6,8 @@ import tempfile
 import os
 import argparse
 import datetime
+from urllib.parse import parse_qs, urlparse
+
 import responses
 
 from .context import opl
@@ -211,16 +213,24 @@ class TestRequestedInfo(unittest.TestCase):
         self.assertEqual(k, None)
         self.assertEqual(v, None)
 
+
 class TestGrafanaPlugin(unittest.TestCase):
 
     mock_post_get_load_simple = {
         "mock": {
             "method": responses.POST,
-            "url": 'http://grafana.example.com:443/api/datasources/proxy/42/render',
-            "json": [{
-                'target': 'someprefix.node001_example_com.load.load.shortterm',
-                'datapoints': [[10.0, 1740787205], [15.0, 1740787220], [5.0, 1740787235], [10.0, 1740787250]]
-            }],
+            "url": "http://grafana.example.com:443/api/datasources/proxy/42/render",
+            "json": [
+                {
+                    "target": "someprefix.node001_example_com.load.load.shortterm",
+                    "datapoints": [
+                        [10.0, 1740787205],
+                        [15.0, 1740787220],
+                        [5.0, 1740787235],
+                        [10.0, 1740787250],
+                    ],
+                }
+            ],
             "status": 200,
         },
         "args": argparse.Namespace(
@@ -324,3 +334,209 @@ class TestGrafanaPlugin(unittest.TestCase):
         self.assertEqual(v["enritchment"]["hello"], "world")
         self.assertEqual(v["enritchment"]["answer"], 42)
         self.assertNotIn("variables", v)
+
+    mock_post_get_batch = {
+        "mock": {
+            "method": responses.POST,
+            "url": "http://grafana.example.com:443/api/datasources/proxy/42/render",
+            "json": [
+                {
+                    "target": "someprefix.node001_example_com.load.load.shortterm",
+                    "datapoints": [[10.0, 1740787205], [15.0, 1740787220]],
+                },
+                {
+                    "target": "someprefix.node001_example_com.memory.memory-used",
+                    "datapoints": [[1000.0, 1740787205], [2000.0, 1740787220]],
+                },
+                {
+                    "target": "someprefix.node001_example_com.swap.swap-used",
+                    "datapoints": [[100.0, 1740787205], [200.0, 1740787220]],
+                },
+            ],
+            "status": 200,
+        },
+        "args": argparse.Namespace(
+            grafana_host="http://grafana.example.com",
+            grafana_port=443,
+            grafana_prefix="someprefix",
+            grafana_datasource=42,
+            grafana_interface="interface-enp2s0",
+            grafana_token="secret",
+            grafana_node="node001_example_com",
+            grafana_chunk_size=10,
+        ),
+        "start": datetime.datetime.fromisoformat("2025-03-01T00:00:00+00:00"),
+        "end": datetime.datetime.fromisoformat("2025-03-01T00:01:00+00:00"),
+    }
+
+    @responses.activate
+    def test_batch_consecutive_targets(self):
+        """Consecutive Grafana items are batched into one HTTP request."""
+        responses.add(**self.mock_post_get_batch["mock"])
+
+        string = """
+            - name: measurement.load
+              grafana_target: $Cloud.$Node.load.load.shortterm
+            - name: measurement.memory
+              grafana_target: $Cloud.$Node.memory.memory-used
+            - name: measurement.swap
+              grafana_target: $Cloud.$Node.swap.swap-used
+        """
+
+        ri = opl.cluster_read.RequestedInfo(
+            string,
+            start=self.mock_post_get_batch["start"],
+            end=self.mock_post_get_batch["end"],
+            args=self.mock_post_get_batch["args"],
+        )
+        results = list(ri)
+        self.assertEqual(len(results), 3)
+        self.assertEqual(results[0][0], "measurement.load")
+        self.assertEqual(int(results[0][1]["mean"]), 12)
+        self.assertEqual(results[1][0], "measurement.memory")
+        self.assertEqual(int(results[1][1]["mean"]), 1500)
+        self.assertEqual(results[2][0], "measurement.swap")
+        self.assertEqual(int(results[2][1]["mean"]), 150)
+        # Only one HTTP request should have been made
+        self.assertEqual(len(responses.calls), 1)
+        # All parameters must be in POST body, not query string
+        req = responses.calls[0].request
+        self.assertEqual(urlparse(req.url).query, "")
+        body = parse_qs(req.body)
+        self.assertEqual(len(body["target"]), 3)
+        self.assertIn("from", body)
+        self.assertIn("until", body)
+        self.assertIn("format", body)
+
+    @responses.activate
+    def test_batch_fallback_on_failure(self):
+        """On batch failure, falls back to individual measure() calls."""
+        # First call (batch) fails, next 3 individual calls succeed
+        responses.add(
+            method=responses.POST,
+            url="http://grafana.example.com:443/api/datasources/proxy/42/render",
+            json={"error": "server error"},
+            status=500,
+        )
+        for target_data in self.mock_post_get_batch["mock"]["json"]:
+            responses.add(
+                method=responses.POST,
+                url="http://grafana.example.com:443/api/datasources/proxy/42/render",
+                json=[target_data],
+                status=200,
+            )
+
+        string = """
+            - name: measurement.load
+              grafana_target: $Cloud.$Node.load.load.shortterm
+            - name: measurement.memory
+              grafana_target: $Cloud.$Node.memory.memory-used
+            - name: measurement.swap
+              grafana_target: $Cloud.$Node.swap.swap-used
+        """
+
+        ri = opl.cluster_read.RequestedInfo(
+            string,
+            start=self.mock_post_get_batch["start"],
+            end=self.mock_post_get_batch["end"],
+            args=self.mock_post_get_batch["args"],
+        )
+        results = list(ri)
+        self.assertEqual(len(results), 3)
+        self.assertEqual(results[0][0], "measurement.load")
+        self.assertEqual(int(results[0][1]["mean"]), 12)
+        self.assertEqual(results[1][0], "measurement.memory")
+        self.assertEqual(int(results[1][1]["mean"]), 1500)
+        self.assertEqual(results[2][0], "measurement.swap")
+        self.assertEqual(int(results[2][1]["mean"]), 150)
+
+    @responses.activate
+    def test_batch_boundary_at_non_grafana_item(self):
+        """Non-Grafana items between Grafana items create batch boundaries."""
+        # Two separate batch requests expected
+        responses.add(
+            method=responses.POST,
+            url="http://grafana.example.com:443/api/datasources/proxy/42/render",
+            json=[self.mock_post_get_batch["mock"]["json"][0]],
+            status=200,
+        )
+        responses.add(
+            method=responses.POST,
+            url="http://grafana.example.com:443/api/datasources/proxy/42/render",
+            json=[self.mock_post_get_batch["mock"]["json"][2]],
+            status=200,
+        )
+
+        string = """
+            - name: measurement.load
+              grafana_target: $Cloud.$Node.load.load.shortterm
+            - name: measurement.group
+              constant: mygroup
+            - name: measurement.swap
+              grafana_target: $Cloud.$Node.swap.swap-used
+        """
+
+        ri = opl.cluster_read.RequestedInfo(
+            string,
+            start=self.mock_post_get_batch["start"],
+            end=self.mock_post_get_batch["end"],
+            args=self.mock_post_get_batch["args"],
+        )
+        results = list(ri)
+        self.assertEqual(len(results), 3)
+        self.assertEqual(results[0][0], "measurement.load")
+        self.assertEqual(results[1][0], "measurement.group")
+        self.assertEqual(results[1][1], "mygroup")
+        self.assertEqual(results[2][0], "measurement.swap")
+        # Two HTTP requests (two batches, split by constant)
+        self.assertEqual(len(responses.calls), 2)
+
+    @responses.activate
+    def test_batch_output_matches_individual_output(self):
+        """Batched output must be identical to single-item output."""
+        string = """
+            - name: measurement.load
+              grafana_target: $Cloud.$Node.load.load.shortterm
+            - name: measurement.memory
+              grafana_target: $Cloud.$Node.memory.memory-used
+            - name: measurement.swap
+              grafana_target: $Cloud.$Node.swap.swap-used
+        """
+
+        # Run with chunk_size=1 (individual requests, old behavior)
+        for target_data in self.mock_post_get_batch["mock"]["json"]:
+            responses.add(
+                method=responses.POST,
+                url="http://grafana.example.com:443/api/datasources/proxy/42/render",
+                json=[target_data],
+                status=200,
+            )
+
+        args_single = argparse.Namespace(
+            **{**vars(self.mock_post_get_batch["args"]), "grafana_chunk_size": 1}
+        )
+        single = list(
+            opl.cluster_read.RequestedInfo(
+                string,
+                start=self.mock_post_get_batch["start"],
+                end=self.mock_post_get_batch["end"],
+                args=args_single,
+            )
+        )
+
+        # Run with chunk_size=50 (batched, new behavior)
+        responses.add(**self.mock_post_get_batch["mock"])
+
+        args_batched = argparse.Namespace(
+            **{**vars(self.mock_post_get_batch["args"]), "grafana_chunk_size": 50}
+        )
+        batched = list(
+            opl.cluster_read.RequestedInfo(
+                string,
+                start=self.mock_post_get_batch["start"],
+                end=self.mock_post_get_batch["end"],
+                args=args_batched,
+            )
+        )
+
+        self.assertEqual(single, batched)

--- a/tests/test_cluster_read.py
+++ b/tests/test_cluster_read.py
@@ -369,27 +369,33 @@ class TestGrafanaPlugin(unittest.TestCase):
         "end": datetime.datetime.fromisoformat("2025-03-01T00:01:00+00:00"),
     }
 
-    @responses.activate
-    def test_batch_consecutive_targets(self):
-        """Consecutive Grafana items are batched into one HTTP request."""
-        responses.add(**self.mock_post_get_batch["mock"])
+    batch_string = """
+        - name: measurement.load
+          grafana_target: $Cloud.$Node.load.load.shortterm
+        - name: measurement.memory
+          grafana_target: $Cloud.$Node.memory.memory-used
+        - name: measurement.swap
+          grafana_target: $Cloud.$Node.swap.swap-used
+    """
 
-        string = """
-            - name: measurement.load
-              grafana_target: $Cloud.$Node.load.load.shortterm
-            - name: measurement.memory
-              grafana_target: $Cloud.$Node.memory.memory-used
-            - name: measurement.swap
-              grafana_target: $Cloud.$Node.swap.swap-used
-        """
+    batch_boundary_string = """
+        - name: measurement.load
+          grafana_target: $Cloud.$Node.load.load.shortterm
+        - name: measurement.group
+          constant: mygroup
+        - name: measurement.swap
+          grafana_target: $Cloud.$Node.swap.swap-used
+    """
 
-        ri = opl.cluster_read.RequestedInfo(
-            string,
+    def _make_batch_requested_info(self, string=None, args=None):
+        return opl.cluster_read.RequestedInfo(
+            string or self.batch_string,
             start=self.mock_post_get_batch["start"],
             end=self.mock_post_get_batch["end"],
-            args=self.mock_post_get_batch["args"],
+            args=args or self.mock_post_get_batch["args"],
         )
-        results = list(ri)
+
+    def _assert_batch_results(self, results):
         self.assertEqual(len(results), 3)
         self.assertEqual(results[0][0], "measurement.load")
         self.assertEqual(int(results[0][1]["mean"]), 12)
@@ -397,6 +403,14 @@ class TestGrafanaPlugin(unittest.TestCase):
         self.assertEqual(int(results[1][1]["mean"]), 1500)
         self.assertEqual(results[2][0], "measurement.swap")
         self.assertEqual(int(results[2][1]["mean"]), 150)
+
+    @responses.activate
+    def test_batch_consecutive_targets(self):
+        """Consecutive Grafana items are batched into one HTTP request."""
+        responses.add(**self.mock_post_get_batch["mock"])
+        ri = self._make_batch_requested_info()
+        results = list(ri)
+        self._assert_batch_results(results)
         # Only one HTTP request should have been made
         self.assertEqual(len(responses.calls), 1)
         # All parameters must be in POST body, not query string
@@ -425,30 +439,9 @@ class TestGrafanaPlugin(unittest.TestCase):
                 json=[target_data],
                 status=200,
             )
-
-        string = """
-            - name: measurement.load
-              grafana_target: $Cloud.$Node.load.load.shortterm
-            - name: measurement.memory
-              grafana_target: $Cloud.$Node.memory.memory-used
-            - name: measurement.swap
-              grafana_target: $Cloud.$Node.swap.swap-used
-        """
-
-        ri = opl.cluster_read.RequestedInfo(
-            string,
-            start=self.mock_post_get_batch["start"],
-            end=self.mock_post_get_batch["end"],
-            args=self.mock_post_get_batch["args"],
-        )
+        ri = self._make_batch_requested_info()
         results = list(ri)
-        self.assertEqual(len(results), 3)
-        self.assertEqual(results[0][0], "measurement.load")
-        self.assertEqual(int(results[0][1]["mean"]), 12)
-        self.assertEqual(results[1][0], "measurement.memory")
-        self.assertEqual(int(results[1][1]["mean"]), 1500)
-        self.assertEqual(results[2][0], "measurement.swap")
-        self.assertEqual(int(results[2][1]["mean"]), 150)
+        self._assert_batch_results(results)
 
     @responses.activate
     def test_batch_boundary_at_non_grafana_item(self):
@@ -466,22 +459,7 @@ class TestGrafanaPlugin(unittest.TestCase):
             json=[self.mock_post_get_batch["mock"]["json"][2]],
             status=200,
         )
-
-        string = """
-            - name: measurement.load
-              grafana_target: $Cloud.$Node.load.load.shortterm
-            - name: measurement.group
-              constant: mygroup
-            - name: measurement.swap
-              grafana_target: $Cloud.$Node.swap.swap-used
-        """
-
-        ri = opl.cluster_read.RequestedInfo(
-            string,
-            start=self.mock_post_get_batch["start"],
-            end=self.mock_post_get_batch["end"],
-            args=self.mock_post_get_batch["args"],
-        )
+        ri = self._make_batch_requested_info(self.batch_boundary_string)
         results = list(ri)
         self.assertEqual(len(results), 3)
         self.assertEqual(results[0][0], "measurement.load")
@@ -494,15 +472,6 @@ class TestGrafanaPlugin(unittest.TestCase):
     @responses.activate
     def test_batch_output_matches_individual_output(self):
         """Batched output must be identical to single-item output."""
-        string = """
-            - name: measurement.load
-              grafana_target: $Cloud.$Node.load.load.shortterm
-            - name: measurement.memory
-              grafana_target: $Cloud.$Node.memory.memory-used
-            - name: measurement.swap
-              grafana_target: $Cloud.$Node.swap.swap-used
-        """
-
         # Run with chunk_size=1 (individual requests, old behavior)
         for target_data in self.mock_post_get_batch["mock"]["json"]:
             responses.add(
@@ -515,14 +484,7 @@ class TestGrafanaPlugin(unittest.TestCase):
         args_single = argparse.Namespace(
             **{**vars(self.mock_post_get_batch["args"]), "grafana_chunk_size": 1}
         )
-        single = list(
-            opl.cluster_read.RequestedInfo(
-                string,
-                start=self.mock_post_get_batch["start"],
-                end=self.mock_post_get_batch["end"],
-                args=args_single,
-            )
-        )
+        single = list(self._make_batch_requested_info(args=args_single))
 
         # Run with chunk_size=50 (batched, new behavior)
         responses.add(**self.mock_post_get_batch["mock"])
@@ -530,13 +492,6 @@ class TestGrafanaPlugin(unittest.TestCase):
         args_batched = argparse.Namespace(
             **{**vars(self.mock_post_get_batch["args"]), "grafana_chunk_size": 50}
         )
-        batched = list(
-            opl.cluster_read.RequestedInfo(
-                string,
-                start=self.mock_post_get_batch["start"],
-                end=self.mock_post_get_batch["end"],
-                args=args_batched,
-            )
-        )
+        batched = list(self._make_batch_requested_info(args=args_batched))
 
         self.assertEqual(single, batched)


### PR DESCRIPTION
Reduce Grafana HTTP round-trips by batching consecutive targets into a single render request. Plugins opt in by implementing measure_many() and batch_size; the iterator groups and delegates automatically.

On batch failure, falls back to individual measure() calls with per-target @retry, preserving the original resilience.

- Targets sent as POST body (data=) to avoid URI length limits
- requests.Session() reuses connections across requests
- --grafana-chunk-size default raised to 50 (configurable)
- NoDataException restored for Prometheus plugin

28s → 9s per node in production (49 requests → 1).