### PR TITLE
Fix --relatives bug to generate distinct org_ids per relative

### DIFF
--- a/extras/opl/generators/inventory_ingress.py
+++ b/extras/opl/generators/inventory_ingress.py
@@ -75,13 +75,10 @@ class InventoryIngressGenerator(opl.generators.generic.GenericGenerator):
                 for i in self.per_account_data  # because per_account_data is a list not dictionary
             ]
         else:
-            common_acc_orgid = (
-                self._get_account()
-            )  # since hbi has same account and org_id values
             return [
                 {
-                    "account": common_acc_orgid,
-                    "orgid": common_acc_orgid,
+                    "account": self._get_account(),
+                    "orgid": self._get_account(),
                     "satellite_id": self._get_uuid(),
                     "satellite_instance_id": self._get_uuid(),
                 }

--- a/extras/opl/generators/inventory_ingress.py
+++ b/extras/opl/generators/inventory_ingress.py
@@ -75,15 +75,19 @@ class InventoryIngressGenerator(opl.generators.generic.GenericGenerator):
                 for i in self.per_account_data  # because per_account_data is a list not dictionary
             ]
         else:
-            return [
-                {
-                    "account": self._get_account(),
-                    "orgid": self._get_account(),
-                    "satellite_id": self._get_uuid(),
-                    "satellite_instance_id": self._get_uuid(),
-                }
-                for i in range(relatives)
-            ]
+            # Distinct account/org_id per relative; HBI RHSM path keeps them equal.
+            relatives_list = []
+            for _ in range(relatives):
+                acc_orgid = self._get_account()
+                relatives_list.append(
+                    {
+                        "account": acc_orgid,
+                        "orgid": acc_orgid,
+                        "satellite_id": self._get_uuid(),
+                        "satellite_instance_id": self._get_uuid(),
+                    }
+                )
+            return relatives_list
 
     def _mid(self, data):
         return data["subscription_manager_id"]


### PR DESCRIPTION
The _get_relatives() method was incorrectly creating the same org_id for all relatives by calling self._get_account() once outside the loop and reusing the value. This caused all hosts to be associated with the same organization regardless of the --relatives parameter value.

Fixed by moving self._get_account() calls inside the list comprehension so each relative gets a unique org_id, enabling proper multi-tenant performance testing scenarios.