### PR TITLE
Fix Horreum label creation by sending array payload to API

### DIFF
--- a/extras/opl/horreum_api.py
+++ b/extras/opl/horreum_api.py
@@ -182,7 +182,7 @@ class HorreumAPI:
             }
 
         url = f"{self.base_url}/api/schema/{schema_id}/labels"
-        response = self.session.post(url, json=label_data)
+        response = self.session.post(url, json=[label_data])
         response.raise_for_status()
         return response.json()
 


### PR DESCRIPTION
## Summary

Fixes label creation failures in `HorreumAPI.create_label` by sending the request body as a JSON array instead of a single object.

`POST /api/schema/{id}/labels` was returning `400 Bad Request` with an empty response body because `create_label` posted `json=label_data` (a single object). The Horreum API expects an array of label objects, consistent with `GET /api/schema/{id}/labels`, which returns a list.

**Change:** wrap the payload in `create_label`:

```python
response = self.session.post(url, json=[label_data])
```