### PR TITLE
Remove buffer_memory param unsupported in kafka-python 3.x

### DIFF
--- a/core/opl/args.py
+++ b/core/opl/args.py
@@ -172,10 +172,10 @@ def add_kafka_opts(parser):
         help="Max size of the batch before sending (also use env variable KAFKA_BATCH_SIZE)",
     )
     parser.add_argument(
-        "--kafka-buffer-memory",
+        "--kafka-max-request-size",
         type=int,
-        default=int(os.getenv("KAFKA_BUFFER_MEMORY", 33554432)),
-        help="Memory the producer can use at max for batching (also use env variable KAFKA_BUFFER_MEMORY)",
+        default=int(os.getenv("KAFKA_MAX_REQUEST_SIZE", 1048576)),
+        help="Maximum size of a requests in bytes, effectively a cap on the maximum record size (also use env variable KAFKA_MAX_REQUEST_SIZE)",
     )
     parser.add_argument(
         "--kafka-retries",

--- a/extras/opl/kafka_init.py
+++ b/extras/opl/kafka_init.py
@@ -39,7 +39,7 @@ class kafka_init:
                 "linger_ms": getattr(args, "kafka_linger_ms", 0),
                 "compression_type": getattr(args, "kafka_compression_type", None),
                 "batch_size": getattr(args, "kafka_batch_size", 16384),
-                "buffer_memory": getattr(args, "kafka_buffer_memory", 33554432),
+                "max_request_size": getattr(args, "kafka_max_request_size", 1048576),
                 "retries": getattr(args, "kafka_retries", 0),
             }
 


### PR DESCRIPTION
The buffer_memory producer config was removed in kafka-python 3.0, causing ValueError on pod startup. Drop the parameter from the producer init and the corresponding --kafka-buffer-memory CLI argument.