### PR TITLE
Fix IndexError when RP test item has empty defects dict

### DIFF
--- a/core/opl/status_data_updater.py
+++ b/core/opl/status_data_updater.py
@@ -361,7 +361,10 @@ def _get_es_dashboard_result_for_run_id(session, args, run_id, test=None):
 
 
 def _get_rp_result_defect_string(result):
-    return list(result["statistics"]["defects"].keys())[0]
+    keys = list(result["statistics"]["defects"].keys())
+    if not keys:
+        return "to_investigate"
+    return keys[0]
 
 
 def _get_rp_result_result_string(result):


### PR DESCRIPTION
## Summary

- Fix `IndexError: list index out of range` crash in `_get_rp_result_defect_string()` when a ReportPortal test item has `statistics.defects` as an empty dict
- This happens when a test is FAILED and RP fails to generate the TI indicator and defects dict has no keys:
<img width="688" height="318" alt="image" src="https://github.com/user-attachments/assets/f4dd3246-48ae-48c9-a653-c8c6cca98a04" />

- Treat uninvestigated items as `to_investigate` which maps to `FAIL` in ES, matching the expected behavior

## Root Cause

The `UtilResultsFromRPToES` Jenkins job crashes when syncing results from RP to ES because:
```python
list(result["statistics"]["defects"].keys())[0]  # {} has no keys → IndexError
```

## Test plan

- [x] Verified the empty defects dict from RP launch 33498 (DeleteResource test)
- [x] Confirmed the fix returns `"to_investigate"` for empty defects, which maps to `FAIL`
- [x] Existing defect types (`no_defect`, `product_bug`, etc.) continue to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)