### PR TITLE
Fix Node.js 20 is deprecated warning

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,7 +8,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -32,6 +32,3 @@ jobs:
         VALIDATE_ALL_CODEBASE: false #set this to true if you want the linter to always check the entire codebase instead of the committed changes. NOT CONVINIENT IF THERE IS A LOT OF CODE
         VALIDATE_YAML: false
         VALIDATE_CSS: false
-
-
-


### PR DESCRIPTION
Warning: 
Node.js 20 is deprecated.
The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v3.[2]

Fix:
Use checkout@v4 instead of v3 .[1]

[1] https://github.com/orgs/community/discussions/190988
[2] https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners