### PR TITLE
fix(RHIDP_15096): handle missing 'parameters' key in elasticsearch_loader.py

### DIFF
--- a/core/opl/investigator/elasticsearch_loader.py
+++ b/core/opl/investigator/elasticsearch_loader.py
@@ -40,9 +40,8 @@ def load(server, index, query, paths, **kwargs):
         response = opl.http.get(url, headers=headers, json=data)
 
     for item in response["hits"]["hits"]:
-        logging.debug(
-            f"Loading data from document ID {item['_id']} with field id={item['_source']['id'] if 'id' in item['_source'] else None} or parameters.run={item['_source']['parameters']['run'] if 'run' in item['_source']['parameters'] else None}"
-        )
+        params = item['_source'].get('parameters', {})
+        logging.debug(f"Loading data from document ID {item['_id']} with field id={item['_source'].get('id')} or parameters.run={params.get('run')}")
         tmpfile = tempfile.NamedTemporaryFile(prefix=item["_id"], delete=False).name
         sd = opl.status_data.StatusData(
             tmpfile, data=item["_source"], skip_metadata_assert=skip_metadata_assert

--- a/core/opl/investigator/elasticsearch_loader.py
+++ b/core/opl/investigator/elasticsearch_loader.py
@@ -40,8 +40,10 @@ def load(server, index, query, paths, **kwargs):
         response = opl.http.get(url, headers=headers, json=data)
 
     for item in response["hits"]["hits"]:
-        params = item['_source'].get('parameters', {})
-        logging.debug(f"Loading data from document ID {item['_id']} with field id={item['_source'].get('id')} or parameters.run={params.get('run')}")
+        params = item["_source"].get("parameters", {})
+        logging.debug(
+            f"Loading data from document ID {item['_id']} with field id={item['_source'].get('id')} or parameters.run={params.get('run')}"
+        )
         tmpfile = tempfile.NamedTemporaryFile(prefix=item["_id"], delete=False).name
         sd = opl.status_data.StatusData(
             tmpfile, data=item["_source"], skip_metadata_assert=skip_metadata_assert


### PR DESCRIPTION
…ader

      item['_source']['parameters'] raises KeyError when documents
      don't include a 'parameters' field. Guard with .get()

Signed-off-by: skestwal <skestwal@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED