### PR TITLE
Fix add_to_suite losing the testcase under junitparser>=5

### DIFF
--- a/core/opl/junit_cli.py
+++ b/core/opl/junit_cli.py
@@ -108,13 +108,12 @@ class JUnitXmlPlus(junitparser.JUnitXml):
         case.add_property("start", new["start"].isoformat())
         case.add_property("end", new["end"].isoformat())
 
-        suite_found = False
         for suite in self:
             if suite.name == suite_name:
                 logging.debug(f"Suite {suite_name} found, going to add into it")
                 suite.add_testcase(case)
-                suite_found = True
-        if not suite_found:
+                break
+        else:
             # Add the testcase before add_testsuite(), not after: newer
             # junitparser versions deepcopy the suite on add_testsuite(),
             # so the tree would keep a copy made before the testcase existed

--- a/core/opl/junit_cli.py
+++ b/core/opl/junit_cli.py
@@ -75,16 +75,6 @@ class JUnitXmlPlus(junitparser.JUnitXml):
     def add_to_suite(self, suite_name, new):
         case = TestCaseWithProp(new["name"])
 
-        suite_found = False
-        for suite in self:
-            if suite.name == suite_name:
-                logging.debug(f"Suite {suite_name} found, going to add into it")
-                suite_found = True
-        if not suite_found:
-            logging.debug(f"Suite {suite_name} not found, creating new one")
-            suite = junitparser.TestSuite(suite_name)
-            self.add_testsuite(suite)
-
         if new["result"] == "PASS":
             case.result = []
         elif new["result"] == "FAIL":
@@ -118,7 +108,21 @@ class JUnitXmlPlus(junitparser.JUnitXml):
         case.add_property("start", new["start"].isoformat())
         case.add_property("end", new["end"].isoformat())
 
-        suite.add_testcase(case)
+        suite_found = False
+        for suite in self:
+            if suite.name == suite_name:
+                logging.debug(f"Suite {suite_name} found, going to add into it")
+                suite.add_testcase(case)
+                suite_found = True
+        if not suite_found:
+            # Add the testcase before add_testsuite(), not after: newer
+            # junitparser versions deepcopy the suite on add_testsuite(),
+            # so the tree would keep a copy made before the testcase existed
+            # and any case added afterwards would silently be lost.
+            logging.debug(f"Suite {suite_name} not found, creating new one")
+            suite = junitparser.TestSuite(suite_name)
+            suite.add_testcase(case)
+            self.add_testsuite(suite)
 
         self.write()
 

--- a/tests/test_junit_cli.py
+++ b/tests/test_junit_cli.py
@@ -60,3 +60,55 @@ class TestJUnitXmlPlus(unittest.TestCase):
         self.assertEqual(case2.name, "ccc")
         self.assertEqual(len(case2.result), 1)
         self.assertEqual(type(case2.result[0]), junitparser.junitparser.Failure)
+
+    def test_add_to_suite_new_suite_keeps_testcase(self):
+        """
+        Regression test: a single add_to_suite() call for a suite that
+        does not exist yet must actually contain the testcase
+        afterwards. junitparser>=5 deepcopies the suite inside
+        add_testsuite(), so adding the testcase to the suite object
+        *after* handing it to add_testsuite() would silently attach it
+        to an orphaned copy, leaving the real suite in the tree empty.
+        """
+        tc = {
+            "name": "bbb",
+            "result": "PASS",
+            "message": None,
+            "system-out": None,
+            "system-err": None,
+            "start": opl.date.my_fromisoformat("2019-12-18T14:05:33+01:00"),
+            "end": opl.date.my_fromisoformat("2019-12-18T14:10:56+01:00"),
+        }
+
+        self.junit.add_to_suite("aaa", tc)
+
+        suite = next(iter(self.junit))
+        self.assertEqual(suite.name, "aaa")
+        cases = list(suite)
+        self.assertEqual(len(cases), 1)
+        self.assertEqual(cases[0].name, "bbb")
+
+    def test_add_to_suite_new_suite_persists_to_file(self):
+        """
+        Same as test_add_to_suite_new_suite_keeps_testcase, but reloads
+        the file from disk afterwards - matching how junit_cli.py is
+        actually used, where "add" and "upload" are separate CLI
+        invocations reading back a previously written file.
+        """
+        tc = {
+            "name": "bbb",
+            "result": "PASS",
+            "message": None,
+            "system-out": None,
+            "system-err": None,
+            "start": opl.date.my_fromisoformat("2019-12-18T14:05:33+01:00"),
+            "end": opl.date.my_fromisoformat("2019-12-18T14:10:56+01:00"),
+        }
+
+        self.junit.add_to_suite("aaa", tc)
+
+        reloaded = opl.junit_cli.JUnitXmlPlus.fromfile_or_new(self.junit.filepath)
+        suite = next(iter(reloaded))
+        cases = list(suite)
+        self.assertEqual(len(cases), 1)
+        self.assertEqual(cases[0].name, "bbb")


### PR DESCRIPTION
## Summary
- `TestSuite.add_testsuite()` in junitparser 5.x deep-copies the suite before appending it to the tree (a behavior change from 4.x). `add_to_suite()` created a new `TestSuite`, passed it to `add_testsuite()` immediately, then mutated the same (now orphaned) suite object by adding the testcase afterward — the tree kept the pre-testcase deep copy, so the case silently vanished with no exception anywhere in the call chain.
- Since a caller's per-run-unique junit filename always hits the "new suite" path, this affects every single such run consistently (not intermittent) once an environment resolves `junitparser>=5`, while environments still pinned to `junitparser<5` are unaffected — a `pip install -e git+...` without an upper bound means different agents can silently drift onto different junitparser majors.
- In our case this produced ReportPortal launches with a bare item and no attached log, despite the pipeline reporting success at every step (`add`, `upload`, and Ibutsu import all exit 0/succeed since nothing raises).

## Fix
Attach the testcase to the suite before it is ever passed to `add_testsuite()`, so newer junitparser's deep copy carries it along. Both the new-suite and existing-suite code paths are otherwise unchanged.

## Test plan
- [x] Reproduced the bug against a real production `status-data-*.json`/log files with `junitparser==5.0.1`: `add` for PASS/FAIL/ERROR all produced an empty `<testsuite/>` (no exception, exit code 0).
- [x] Applied the fix and reproduced both the new-suite and existing-suite code paths locally — both now correctly populate the `<testcase>`.
- [x] Existing `tests/test_junit_cli.py::test_add_to_suite` still passes.
- [x] Verified end-to-end against a real Jenkins-triggered pipeline run (patched the fix into the agent's venv mid-run): the resulting `junit-*.xml` went from 111 bytes (empty) to ~15KB with a populated `<system-out>`, and the resulting ReportPortal launch showed a proper 3-level hierarchy (launch → suite → item) with the log attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)